### PR TITLE
Enable behind-proxy installation

### DIFF
--- a/deb.mk
+++ b/deb.mk
@@ -92,7 +92,7 @@ deb-herokuish:
 	@echo "  sudo docker rmi gliderlabs/herokuish" >> /tmp/tmp/post-install
 	@echo "fi" >> /tmp/tmp/post-install
 	@echo "echo 'Importing herokuish into docker (around 5 minutes)'" >> /tmp/tmp/post-install
-	@echo "sudo docker build -t gliderlabs/herokuish /var/lib/herokuish 1> /dev/null" >> /tmp/tmp/post-install
+	@echo "sudo docker build --build-args http_proxy=$http_proxy --build-args https_proxy=$https_proxy -t gliderlabs/herokuish /var/lib/herokuish 1> /dev/null" >> /tmp/tmp/post-install
 
 	@echo "-> Cloning repository"
 	git clone -q "https://github.com/$(HEROKUISH_REPO_NAME).git" --branch "v$(HEROKUISH_VERSION)" /tmp/tmp/herokuish > /dev/null


### PR DESCRIPTION
As long as your environment has http_proxy and/or https_proxy envvars defined (e.g. via a file in /etc/profile.d), this will allow the package to successfully install in corporate behind-proxy situations.

It is harmless in situations where these envvars have not been defined.